### PR TITLE
Hull together steps to prevent gaps

### DIFF
--- a/bend.scad
+++ b/bend.scad
@@ -9,6 +9,17 @@
 // dimensions: vector with dimensions of the object that should be bent
 // radius:     distance of the cylinder axis
 // nsteps:     number of parts the object will be split into before being bent 
+
+module cylindric_bend_step(radius, step, step_angle, step_width, dimensions){
+  translate([0, radius * sin(step * step_angle), radius * (1 - cos(step * step_angle))])
+    rotate(step_angle * step, [1, 0, 0])
+    translate([0, -step * step_width, 0])
+    intersection() {
+    children();
+    translate([0, (step - 0.5) * step_width, 0])
+      cube([dimensions.x, step_width, dimensions.z]);
+  }
+}
 module cylindric_bend(dimensions, radius, nsteps = $fn) {
   step_angle = nsteps == 0 ? $fa : atan(dimensions.y/(radius * nsteps));
   steps = ceil(nsteps == 0 ? dimensions.y/ (tan(step_angle) * radius) : nsteps);
@@ -17,16 +28,12 @@ module cylindric_bend(dimensions, radius, nsteps = $fn) {
     intersection() {
       children();
       cube([dimensions.x, step_width/2, dimensions.z]);
-    }      
-    for (step = [1:steps]) {
-      translate([0, radius * sin(step * step_angle), radius * (1 - cos(step * step_angle))])
-        rotate(step_angle * step, [1, 0, 0])
-          translate([0, -step * step_width, 0])
-            intersection() {
-              children();
-              translate([0, (step - 0.5) * step_width, 0])
-                cube([dimensions.x, step_width, dimensions.z]);
-            }
+    }
+    for (step = [2:steps]) {
+      hull(){
+        cylindric_bend_step(radius, step, step_angle, step_width, dimensions) children();
+        cylindric_bend_step(radius, step-1, step_angle, step_width, dimensions) children();
+      }
     }
   }
 }


### PR DESCRIPTION
I was having issues with seams between each step in the model. It really messed with my slicer when I tried to 3D print the thing. 

Here's a naive refactor that hulls together each step with the previous step. This fixes the gap issue, and my models come out with clean geometry. There is some unintended subtle change in shape though, which looks good on my model but may not be for everyone. Further testing is needed.